### PR TITLE
Fix compiler and warning

### DIFF
--- a/mmo_server/lib/mmo_server/persistence_worker.ex
+++ b/mmo_server/lib/mmo_server/persistence_worker.ex
@@ -17,7 +17,7 @@ defmodule MmoServer.PersistenceWorker do
   end
 
   @impl true
-  def handle_message(_, %Message{data: data} = message, _) do
+  def handle_message(_, %Message{data: _data} = message, _) do
     # persist data using Repo
     message
   end

--- a/mmo_server/mix.exs
+++ b/mmo_server/mix.exs
@@ -7,7 +7,7 @@ defmodule MmoServer.MixProject do
       version: "0.1.0",
       elixir: "~> 1.17",
       elixirc_paths: elixirc_paths(Mix.env()),
-      compilers: [:phoenix] ++ Mix.compilers(),
+      compilers: Mix.compilers(),
       start_permanent: Mix.env() == :prod,
       deps: deps()
     ]


### PR DESCRIPTION
## Summary
- remove deprecated `:phoenix` compiler from `mix.exs`
- silence unused variable warning in `PersistenceWorker`

## Testing
- `mix format` *(fails: command not found)*
- `mix test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686300c723a8833194962612a4c7306f