### PR TITLE
Fix Dockerfile build context

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM elixir:1.17
-WORKDIR /app
+WORKDIR /app/mmo_server
 ENV MIX_ENV=prod
-COPY . .
+COPY mmo_server/ .
 RUN mix local.hex --force && \
     mix local.rebar --force && \
     mix deps.get --only prod && \


### PR DESCRIPTION
## Summary
- correct working directory in Dockerfile so `mix` commands run

## Testing
- `mix test` *(fails: `mix: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68630e97b3948331949816b933f266d8