### PR TITLE
Fix docker build configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,12 @@
 FROM elixir:1.17
 WORKDIR /app/mmo_server
-ENV MIX_ENV=prod
+# Compile the application in the same environment that docker-compose
+# uses for running the container. This avoids requiring production only
+# configuration such as `SECRET_KEY_BASE` during image build.
+ENV MIX_ENV=dev
 COPY mmo_server/ .
 RUN mix local.hex --force && \
     mix local.rebar --force && \
-    mix deps.get --only prod && \
+    mix deps.get && \
     mix compile
 CMD ["mix", "phx.server"]


### PR DESCRIPTION
## Summary
- compile the app in dev mode during docker build so `SECRET_KEY_BASE` isn't required

## Testing
- `mix --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68630fb089788331bf44700476e1112d