### PR TITLE
Fix build by using patched Elixir image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM elixir:1.17
+# Use a patched Elixir image to avoid compilation failures with Broadway
+FROM elixir:1.17.4
 WORKDIR /app/mmo_server
 # Compile the application in the same environment that docker-compose
 # uses for running the container. This avoids requiring production only


### PR DESCRIPTION
## Summary
- use an Elixir image with a patch version to avoid compile errors

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6863114958dc8331a5e07387c3310c3f