### PR TITLE
Fix Dockerfile base image reference

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
-# Use a patched Elixir image to avoid compilation failures with Broadway
-FROM elixir:1.17.4
+# Use the official Elixir image. The 1.17.4 tag does not exist yet,
+# so we fall back to the generic 1.17 tag which always resolves to the
+# latest available patch release.
+FROM elixir:1.17
 WORKDIR /app/mmo_server
 # Compile the application in the same environment that docker-compose
 # uses for running the container. This avoids requiring production only


### PR DESCRIPTION
## Summary
- fix Dockerfile to use an available Elixir base image tag

## Testing
- `mix test` *(fails: `mix: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6863124b54408331b44e90d2cc985178