### PR TITLE
Fix docker build and dependencies

### DIFF
--- a/mmo_server/mix.exs
+++ b/mmo_server/mix.exs
@@ -42,7 +42,9 @@ defmodule MmoServer.MixProject do
       {:delta_crdt, "~> 0.6"},
       {:broadway, "~> 1.0"},
       {:absinthe, "~> 1.7"},
-      {:absinthe_phoenix, "~> 2.0"}
+      {:absinthe_phoenix, "~> 2.0"},
+      {:plug_cowboy, "~> 2.6"},
+      {:jason, "~> 1.4"}
     ]
   end
 end


### PR DESCRIPTION
## Summary
- use hexpm Elixir image so the patch release exists
- install build tools and fetch deps in Dockerfile for better caching

## Testing
- `mix deps.get` *(fails: command not found)*
- `mix test` *(fails: command not found)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_686314d865f8833187f9bfd1bf02b6aa