### PR TITLE
Fix connection issue in Docker compose dev setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     build: .
     environment:
       MIX_ENV: dev
+      DATABASE_HOST: db
     ports:
       - "4000:4000"
     depends_on:

--- a/mmo_server/config/dev.exs
+++ b/mmo_server/config/dev.exs
@@ -4,7 +4,7 @@ config :mmo_server, MmoServer.Repo,
   username: "postgres",
   password: "postgres",
   database: "mmo_server_dev",
-  hostname: "localhost",
+  hostname: System.get_env("DATABASE_HOST") || "localhost",
   show_sensitive_data_on_connection_error: true,
   pool_size: 10
 


### PR DESCRIPTION
## Summary
- configure `MmoServer.Repo` to read database host from `DATABASE_HOST`
- set `DATABASE_HOST` to `db` in docker-compose

## Testing
- `mix --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68632abf5f3883318835682eedcd4227