### PR TITLE
Add alias to setup test database

### DIFF
--- a/mmo_server/mix.exs
+++ b/mmo_server/mix.exs
@@ -26,7 +26,8 @@ defmodule MmoServer.MixProject do
   defp aliases do
     [
       "ecto.setup": ["ecto.create", "ecto.migrate", "seed"],
-      "ecto.reset": ["ecto.drop", "ecto.setup"]
+      "ecto.reset": ["ecto.drop", "ecto.setup"],
+      "test": ["ecto.create --quiet", "ecto.migrate --quiet", "test"]
     ]
   end
 


### PR DESCRIPTION
## Summary
- ensure `mix test` creates test database before running

## Testing
- `elixir -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68632d3128308331ada6bfec8de651a5